### PR TITLE
Add imports from holiday.py in unit test module

### DIFF
--- a/test/feature/test_holiday.py
+++ b/test/feature/test_holiday.py
@@ -41,7 +41,9 @@ from pts.feature.holiday import (
     CYBER_MONDAY,
     SpecialDateFeatureSet,
     squared_exponential_kernel,
-    CustomDateFeatureSet
+    exponential_kernel,
+    CustomDateFeatureSet,
+    CustomHolidayFeatureSet
 )
 
 test_dates = {


### PR DESCRIPTION
Fixes failing unit tests due to missing imports.