### PR TITLE
add history loss

### DIFF
--- a/pts/trainer.py
+++ b/pts/trainer.py
@@ -41,6 +41,8 @@ class Trainer:
         train_iter: DataLoader,
         validation_iter: Optional[DataLoader] = None,
     ) -> None:
+
+        self.history_loss = []
         optimizer = Adam(
             net.parameters(), lr=self.learning_rate, weight_decay=self.weight_decay
         )
@@ -80,7 +82,6 @@ class Trainer:
                         },
                         refresh=False,
                     )
-
                     loss.backward()
                     if self.clip_gradient is not None:
                         nn.utils.clip_grad_norm_(net.parameters(), self.clip_gradient)
@@ -91,6 +92,9 @@ class Trainer:
                     if self.num_batches_per_epoch == batch_no:
                         break
                 it.close()
+
+            # Append the average loss for the epoch to the list of loss values
+            self.history_loss.append(avg_epoch_loss)
 
             # validation loop
             if validation_iter is not None:
@@ -124,3 +128,4 @@ class Trainer:
 
             # mark epoch end time and log time cost of current epoch
             toc = time.time()
+


### PR DESCRIPTION
Add history loss so that users can get the average loss of each epoch and plot these losses. Here is an example:

```python
from pts.model.deepar import DeepAREstimator
from pts import Trainer
import torch

device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

trainer = Trainer(epochs=10, device=device)
estimator = DeepAREstimator(freq="5min",
                            prediction_length=12,
                            input_size=19,
                            trainer=trainer)
predictor = estimator.train(training_data=training_data, num_workers=7)

print(trainer.history_loss)
```
Output: 
```bash
[4.835213756561279,
 4.153376088142395,
 4.0568355321884155,
 4.018129272460937,
 3.988181219100952,
 3.9771962928771973,
 3.9635843515396116,
 3.9477042865753176,
 3.9390473127365113,
 3.9344323682785034]
```
```python
import matplotlib.pyplot as plt 
plt.plot(trainer.history_loss)
```

![Screen Shot 2021-08-11 at 11 26 15 AM](https://user-images.githubusercontent.com/49108771/129066849-ee694648-320c-4f02-9864-ed17c1ef927a.png)
