### PR TITLE
Updated import of gluonts modules

### DIFF
--- a/pts/modules/distribution_output.py
+++ b/pts/modules/distribution_output.py
@@ -31,11 +31,10 @@ from pts.distributions import (
     TransformedImplicitQuantile,
 )
 from gluonts.core.component import validated
-from gluonts.torch.distributions.distribution_output import (
-    DistributionOutput,
-    LambdaLayer,
-    PtArgProj,
-)
+from gluonts.torch.distributions.distribution_output import DistributionOutput
+from gluonts.torch.modules.lambda_layer import LambdaLayer
+from gluonts.torch.distributions.output import PtArgProj
+
 from pts.modules.iqn_modules import ImplicitQuantileModule
 
 


### PR DESCRIPTION
 See issue #167 Import Error in pts/modules/distribution_output.py. Suggested Fix to that import error. 
